### PR TITLE
Remove prepare script to support `pnpm` or different package manager usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sum.cumo/vue-datepicker",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sum.cumo/vue-datepicker",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "prepare": "npm run clear && npm run build",
-    "build": "npm run build:app && npm run build:locale",
+    "build": "npm run clear && npm run build:app && npm run build:locale",
     "build:app": "rollup -c ./scripts/build.js",
     "build:locale": "babel-node scripts/build-locale.js",
     "clear": "rm -rf dist/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sum.cumo/vue-datepicker",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "license": "Apache-2.0",
   "homepage": "https://github.com/sumcumo/vue-datepicker",


### PR DESCRIPTION
### Breaking Changes
- `prepare` script from `package.json` is removed to support pnpm installation, so to release the package, we need to manually run `npm run build` before we merge to the master branch.

### Changes
- Update the `build` script to also run the `clear` command.

